### PR TITLE
fix(security): Sanitize file path input to prevent directory traversal

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.SneakyThrows;
+import org.apache.commons.io.FilenameUtils;
 import okhttp3.ResponseBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -109,7 +110,7 @@ public class ManagedController {
   @Operation(summary = "Get a resource")
   @GetMapping(path = "/resources/{resourceId}")
   Resource getResource(@PathVariable("resourceId") String resourceId) {
-    return Retrofit2SyncCall.execute(keelService.getResource(resourceId));
+    return Retrofit2SyncCall.execute(keelService.getResource(FilenameUtils.getName(resourceId)));
   }
 
   @Operation(summary = "Get a resource")


### PR DESCRIPTION
## Summary
- Applied fix for Semgrep security rule: "Detected user input controlling a file path"  
- Added `FilenameUtils.getName()` to sanitize `resourceId` parameter in `ManagedController.getResource()`
- Prevents potential directory traversal attacks via '../' sequences in user input

## Changes
- Added import for `org.apache.commons.io.FilenameUtils`
- Modified line 113 to use `FilenameUtils.getName(resourceId)` instead of raw `resourceId`
- Ensures only the filename portion is extracted from user-controlled input

## Test plan
- [ ] Verify existing functionality remains intact
- [ ] Test that paths with '../' sequences are properly sanitized
- [ ] Confirm that legitimate resource IDs continue to work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)